### PR TITLE
Cory's Sass Branch

### DIFF
--- a/StyleSheet/_BaseStylesV4.scss
+++ b/StyleSheet/_BaseStylesV4.scss
@@ -997,11 +997,13 @@ h2.noStyle {
 	padding-right: 100px; // /* Gives space at right, so text doesn't overlap into text entry box */
 }
 //Positions these text entry boxes to the right
+$text-input-padding: 2px;
 .Skin .CS .VRTL .SumInput,
 .Skin .CS .VRTL .SumTotal {
 	position:absolute;
 	right: ($default-container-padding / 2) + $default-font-size; // This gives enough space for there to be a symbol to the left or right (e.g., % or $)
-	top: 0px; // 
+	top: 50%; //
+	margin-top: -(($text-input-padding + $default-border-width)* 2 + $default-font-size + 3)/2; //this is the height of the input box plus borders 
 }
 //Makes it so they are HORIZONTAL .HR (could do display: inline-block instead?)
 .Skin .CS .HR li {
@@ -3276,7 +3278,7 @@ a {
 		@if $border-radius-on == T {
 			@include border-radius(2px);
 		}
-		padding: 2px; // If we add too much padding, it cuts off the text (with box-sizing: border-box). Probably stick with 4px or less.
+		padding: $text-input-padding; // If we add too much padding, it cuts off the text (with box-sizing: border-box). Probably stick with 4px or less.
 		// max-width: 100%;	//BOOKMARK: max-width: 100% causes problems in IE8 (the text inputs shrink down to "100%" of the td they are in)
 
 		@if $body-background-image-on == T and $boxed-skincontent == F and $overlay-dark == T or $default-text-color == #FFFFFF {
@@ -3651,10 +3653,6 @@ a {
 	////////////////////////////////////////////////////////////////////
 	.CS .ChoiceStructure li {
 		padding: $default-container-padding / 2;
-	}
-	.CS .VRTL .SumInput input,
-	.CS .VRTL .SumTotal input {
-		margin-top: $default-container-padding / 3;	//This is to vertically center the inputs in Constan Sum.  Not always perfect.  
 	}
 	.CS .CSTotal,
 	.CS .Total {


### PR DESCRIPTION
Input labels had a fixed top margin, so when larger images/content was
displayed it wasn’t centered. They were already positioned absolutely,
just changed the css to center the text input independent of the list
item height.